### PR TITLE
Option to skip missing migration files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except(IOError, ImportError):
 
 setup(
     name='dbschema',
-    version='1.1.1',
+    version='1.1.2',
     description='Schema migration made easy',
     long_description=long_description,
     author='Gabriel Bordeaux',

--- a/src/schema_change.py
+++ b/src/schema_change.py
@@ -15,6 +15,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-c", "--config", type=str, help="Config file location (default: ~/.dbschema.yml)")
 parser.add_argument("-t", "--tag", type=str, help="Database tag")
 parser.add_argument("-r", "--rollback", type=str, help="Rollback a migration")
+parser.add_argument("-s", "--skip_missing", action='store_true', help="Skip missing migration folders")
 args = parser.parse_args()
 
 
@@ -287,7 +288,13 @@ def main():
         postMigration = databases[tag].get('post_migration')
 
         # Check if the migration path exists
-        checExists(path, 'dir')
+        if args.skip_missing:
+            try:
+                checExists(path, 'dir')
+            except RuntimeError:
+                continue
+        else:
+            checExists(path, 'dir')
 
         # Get database connection
         connection = getConnection(engine, host, user, port, password, db)


### PR DESCRIPTION
Add a flag to skip missing migration files without crashing the app.

Without the flag:
```
$ python3 -m src -c local/config.yml
True
 * Applying migrations for db1 (`test` on postgresql)
 * Migrations applied
True
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/dbschema/__main__.py", line 4, in <module>
    schema_change.main()
  File "/dbschema/schema_change.py", line 295, in main
    checExists(path, 'dir')
  File "/dbschema/schema_change.py", line 53, in checExists
    raise RuntimeError('The folder `%s` does not exist.' % path)
RuntimeError: The folder `local/migrations/mysql/` does not exist.
```

With the flagL
```
$ python3 -m src -c local/config.yml -s
 * Applying migrations for db1 (`test` on postgresql)
 * Migrations applied
```