### PR TITLE
Split queries into list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except(IOError, ImportError):
 
 setup(
     name='dbschema',
-    version='1.1.2',
+    version='1.2',
     description='Schema migration made easy',
     long_description=long_description,
     author='Gabriel Bordeaux',

--- a/src/schema_change.py
+++ b/src/schema_change.py
@@ -122,6 +122,18 @@ def getPgConnection(host, user, port, password, database):
     return connection
 
 
+def queriesToList(queries):
+    """
+        Split queries into a list of individual queries
+    """
+
+    # Multiple queries
+    if ';' in queries:
+        return [query for query in queries.split(';') if query.strip()]
+
+    return [queries]
+
+
 def runMigration(connection, queries):
     """
         Apply a migration to the SQL server
@@ -129,8 +141,9 @@ def runMigration(connection, queries):
 
     # Execute query
     with connection.cursor() as cursorMig:
-        cursorMig.execute(queries)
-        connection.commit()
+        for query in queriesToList(queries):
+            cursorMig.execute(query)
+            connection.commit()
 
 
 def saveMigration(connection, basename):


### PR DESCRIPTION
When a migration contains multiple queries they will be split into a list of queries and run individually.

This will fix a bug introduced with PyMySQL version 0.8.0